### PR TITLE
Tail call optimization

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -27,3 +27,8 @@ class Environment(object):
 
     def child(self):
         return Environment(parent=self)
+
+    def height(self):
+        if not self._parent:
+            return 1
+        return 1 + self._parent.height()

--- a/environment.py
+++ b/environment.py
@@ -27,8 +27,3 @@ class Environment(object):
 
     def child(self):
         return Environment(parent=self)
-
-    def height(self):
-        if not self._parent:
-            return 1
-        return 1 + self._parent.height()

--- a/test/tail-call.lisp
+++ b/test/tail-call.lisp
@@ -1,0 +1,7 @@
+(define count
+  (lambda (n)
+    (begin
+     (print! n)
+     (count (+ n 1)))))
+
+(count 0)

--- a/test/tail-call.lisp
+++ b/test/tail-call.lisp
@@ -2,6 +2,22 @@
   (lambda (n)
     (begin
      (print! n)
-     (count (+ n 1)))))
+     (if (< n 10000)
+	 (count (+ n 1))
+       n))))
 
 (count 0)
+
+(define count-a
+  (lambda (n)
+    (if (< n 20000)
+	(count-b (+ n 1))
+      n)))
+
+(define count-b
+  (lambda (n)
+    (begin
+     (print! n)
+     (count-a (+ n 1)))))
+
+(count-a 0)


### PR DESCRIPTION
Delay the execution of function bodies.  Execute the "delayed calls" only once the tail context has been cleaned up, or immediately if they were not in a tail context to begin with.
