### PR TITLE
Allow shorthand function syntax

### DIFF
--- a/datatypes.py
+++ b/datatypes.py
@@ -12,13 +12,13 @@ class Symbol(DataType):
 
 
 class LispFunction(object):
-    def __init__(self, env, arg_names, expr):
+    def __init__(self, env, arg_names, exprs):
         self.env = env
         self.arg_names = arg_names
-        self.expr = expr
+        self.exprs = exprs
 
     def __repr__(self):
-        return "LispFunction[%s -> %s]" % (self.arg_names, self.expr)
+        return "LispFunction[%s -> %s]" % (self.arg_names, self.exprs)
 
 class Pair(namedtuple('Pair', ['car', 'cdr'])):
     def __repr__(self):

--- a/interpreter.py
+++ b/interpreter.py
@@ -18,7 +18,7 @@ def _eval(expr, env, force=True):
     value  = _eval_no_force(expr, env)
     if force:
         while isinstance(value, _DelayedCall):
-            value = _eval_no_force(value.function.expr, value.invocation_env)
+            value = _eval_begin(value.function.exprs, value.invocation_env)
     return value
 
 
@@ -104,8 +104,8 @@ def _eval_define(data, env):
 
 
 def _eval_lambda(data, env):
-    assert len(data) == 2
-    arg_names, implementation = data
+    assert len(data) >= 2
+    arg_names, implementation = data[0], data[1:]
     return datatypes.LispFunction(env, arg_names, implementation)
 
 

--- a/interpreter.py
+++ b/interpreter.py
@@ -98,9 +98,25 @@ def _eval_if(data, env):
 
 
 def _eval_define(data, env):
-    assert len(data) == 2
-    name, expr = data
+    assert data
+    defined = data[0]
+
+    if isinstance(defined, list):
+        assert len(data) >= 2
+        _eval_define_function(defined, data[1:], env)
+    else:
+        assert len(data) == 2
+        _eval_define_variable(defined, data[1], env)
+
+
+def _eval_define_variable(name, expr, env):
     env[name] = _eval(expr, env)
+
+
+def _eval_define_function(definition_spec, implementation, env):
+    assert definition_spec
+    func_name, arg_names = definition_spec[0], definition_spec[1:]
+    env[func_name] = datatypes.LispFunction(env, arg_names, implementation)
 
 
 def _eval_lambda(data, env):

--- a/test/function-syntax.lisp
+++ b/test/function-syntax.lisp
@@ -1,0 +1,10 @@
+(define print-and-double
+  (lambda (x)
+    (print! x)
+    (* 2 x)))
+(print-and-double 5)
+
+(define (print-and-triple x)
+  (print! x)
+  (* 3 x))
+(print-and-triple 15)

--- a/test/tail-call.lisp
+++ b/test/tail-call.lisp
@@ -1,10 +1,9 @@
 (define count
   (lambda (n)
-    (begin
      (print! n)
      (if (< n 10000)
 	 (count (+ n 1))
-       n))))
+       n)))
 
 (count 0)
 
@@ -16,8 +15,7 @@
 
 (define count-b
   (lambda (n)
-    (begin
      (print! n)
-     (count-a (+ n 1)))))
+     (count-a (+ n 1))))
 
 (count-a 0)

--- a/test/tail-call.lisp
+++ b/test/tail-call.lisp
@@ -1,21 +1,15 @@
-(define count
-  (lambda (n)
-     (print! n)
-     (if (< n 10000)
-	 (count (+ n 1))
-       n)))
-
+(define (count n)
+  (print! n)
+  (if (< n 10000)
+      (count (+ n 1))
+    n))
 (count 0)
 
-(define count-a
-  (lambda (n)
-    (if (< n 20000)
-	(count-b (+ n 1))
-      n)))
-
-(define count-b
-  (lambda (n)
-     (print! n)
-     (count-a (+ n 1))))
-
+(define (count-a n)
+  (if (< n 20000)
+      (count-b (+ n 1))
+    n))
+(define (count-b n)
+  (print! n)
+  (count-a (+ n 1)))
 (count-a 0)


### PR DESCRIPTION
Multi-expression lambdas are now allowed, so we no longer must use the `(lambda (x) (begin ...))` trope anymore.  Instead, we can just write `(lambda (x) ...)`, where `...` represents multiple expressions.

Additionally, shorthand function definitions are now allowed.  We no longer must write `(define some-func (lambda (x) ...))`.  Instead, we can write `(define (some-func x) ...)`.
