### PR TITLE
Allow semi-colon comments.

### DIFF
--- a/test/comment.lisp
+++ b/test/comment.lisp
@@ -1,0 +1,18 @@
+; Single semicolon.
+
+;;;; Many semicolons.
+
+
+;;;;;;;;;; Crazy Heading with Trailing Semicolons ;;;;;;;;;
+
+
+(+ 5 5)       ; (+ 10 10) ; Don't execute inline comment!
+
+
+(+ ;; Comment inside a list!
+;; Another comment!
+100 ;; Comment and insidious close paren)
+500 ;; Comment!
+) ;; Comment.
+
+;; Last line is a comment.

--- a/tokenizer.py
+++ b/tokenizer.py
@@ -61,6 +61,7 @@ class Tokenizer(object):
         # special character. At that point those characters are
         # assembled into a token.
         self._current_element = []
+        self._in_comment = False
 
     def _finish_current_token(self):
         token_text = ''.join(self._current_element)
@@ -69,6 +70,13 @@ class Tokenizer(object):
 
     def __iter__(self):
         for char in self._chars:
+            if char == ';':
+                self._in_comment = True
+            if self._in_comment:
+                if char == '\n':
+                    self._in_comment = False
+                continue
+
             if char == "(":
                 yield self._finish_current_token()
                 yield tokens.OpenParen()


### PR DESCRIPTION
These comments start at a semicolon, and go on until the end of the
line.
