### PR TITLE
Implement basic quoting functionality.

### DIFF
--- a/datatypes.py
+++ b/datatypes.py
@@ -20,16 +20,14 @@ def assert_int(value):
     assert isinstance(value, int) or value.denominator == 1
     return int(value)
 
-class Symbol(DataType):
-    """A Scheme symbol equivalent.
 
-    TODO(jasonpr): Justify the existence of symbols in this language.
-    """
-    def __init__(self, name):
-        self.name = name
+class Symbol(DataType):
+    """A Scheme symbol equivalent."""
+    def __init__(self, value):
+        self.value = value
 
     def __repr__(self):
-        return 'Symbol(%s)' % self.name
+        return str(self.value)
 
 
 class LispFunction(DataType):

--- a/formatter.py
+++ b/formatter.py
@@ -3,6 +3,12 @@ import datatypes
 
 def lisp_format(value):
     """Format a Lisp value for display to a human."""
+    # Until we reconcile Lisp lists with Python lists, we use a
+    # special case to format Python lists.
+    # TODO(jasonpr): Remove this special case.
+    if isinstance(value, list):
+        return '(' + ' '.join(lisp_format(elt) for elt in value) + ')'
+
     # Do naked formatting, then wrap with parentheses if needed.
     fmt = '(%s)' if isinstance(value, datatypes.Pair) else '%s'
     return fmt % _naked_format(value)

--- a/interpreter.py
+++ b/interpreter.py
@@ -181,6 +181,16 @@ def _eval_let(data, enclosing_env):
     # as though they were enclosed in a `begin` statement.
     return _eval_begin(exprs, new_env)
 
+def _eval_quote(data, env):
+    assert len(data) == 1
+    quoted_syntax_tree = data[0]
+    if isinstance(quoted_syntax_tree, list):
+        # TODO(jasonpr): Use a Lisp list.
+        return [_eval_quote([subtree], env) for subtree in quoted_syntax_tree]
+    else:
+        return datatypes.Symbol(quoted_syntax_tree)
+
+
 evaluators = {
     'if': _eval_if,
     'define': _eval_define,
@@ -188,6 +198,7 @@ evaluators = {
     'set!': _eval_set,
     'begin': _eval_begin,
     'let': _eval_let,
+    'quote': _eval_quote,
 }
 
 

--- a/parser.py
+++ b/parser.py
@@ -36,15 +36,14 @@ def _parse_integer(token_supply):
     assert isinstance(int_token, tokens.Integer)
     return datatypes.Fraction(int(int_token.text))
 
+
 def _parse_quotation(token_supply):
-    """Parse a symbol."""
+    """Parse a quotation."""
     quote_token = token_supply.next()
     assert isinstance(quote_token, tokens.Quote)
-    quoted_token = token_supply.next()
-    if isinstance(quoted_token, tokens.OpenParen):
-        # TODO(jasonpr): Implement deep quoting.
-        raise NotImplementedError('We can only quote single tokens for now.')
-    return datatypes.Symbol(quoted_token.text)
+    quoted_syntax = _parse(token_supply)
+    return ['quote', quoted_syntax]
+
 
 def _parse_boolean(token_supply):
     """Parse a boolean literal."""


### PR DESCRIPTION
That is, implement the quote function and its synonym, `'`.

The implementation has some bugs:
- The `Symbol` datatype is either oversimple or sometimes applied in incorrect scenarios.  For example, `(quote 2)` yields `Symbol(2)` which does not behave like the integer `2`.  In the MIT Scheme implementation, we can do `(+ '2 '2)` which yields 4.  But, in our implementation, the addition function chokes when it receives a `Symbol` where it expects a number.
- The interpreter represents lists of syntax elements as Python lists, and the `quote` mechanism follows suit.  But, that makes it impossible to do `(car '(1 2 3))`. It is likely that we'll want to eliminate the Python lists from the interpreter, and use Lisp lists instead.
